### PR TITLE
Optimizes imports and resolves Details title spacing issue

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -15,7 +15,7 @@
         <entry key="app/src/main/res/drawable/favorite_unchecked.xml" value="0.12135416666666667" />
         <entry key="app/src/main/res/drawable/map_icon.xml" value="0.17604166666666668" />
         <entry key="app/src/main/res/layout/border_layout.xml" value="0.16983695652173914" />
-        <entry key="app/src/main/res/layout/detail_fragment.xml" value="0.335" />
+        <entry key="app/src/main/res/layout/detail_fragment.xml" value="0.25" />
         <entry key="app/src/main/res/layout/fragment_map.xml" value="0.25" />
         <entry key="app/src/main/res/layout/main_activity.xml" value="0.13541666666666666" />
         <entry key="app/src/main/res/layout/main_fragment.xml" value="0.361731843575419" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdk 26
         targetSdk 31
         versionCode 1
-        versionName "1.0"
+        versionName "1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/finder/MainActivity.kt
+++ b/app/src/main/java/com/finder/MainActivity.kt
@@ -5,10 +5,8 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.os.Looper
 import android.provider.Settings
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog

--- a/app/src/main/java/com/finder/Suggestion.kt
+++ b/app/src/main/java/com/finder/Suggestion.kt
@@ -2,7 +2,6 @@ package com.finder
 
 import android.os.Parcelable
 import androidx.room.Entity
-import androidx.room.Ignore
 import androidx.room.PrimaryKey
 import kotlinx.parcelize.Parcelize
 import java.io.Serializable

--- a/app/src/main/java/com/finder/di/PlacesComponent.kt
+++ b/app/src/main/java/com/finder/di/PlacesComponent.kt
@@ -1,13 +1,10 @@
 package com.finder.di
 
-import com.finder.MainActivity
-import com.finder.MyApp
 import com.finder.networking.PlacesManager
 import com.finder.ui.detail.DetailViewModel
 import com.finder.ui.main.MainViewModel
 import dagger.Component
 import javax.inject.Singleton
-
 
 @Singleton
 @Component(modules = [PlacesManagerModule::class])

--- a/app/src/main/java/com/finder/networking/PlacesApi.kt
+++ b/app/src/main/java/com/finder/networking/PlacesApi.kt
@@ -1,9 +1,9 @@
 package com.finder.networking
 
 import com.finder.BuildConfig
+import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Query
-import retrofit2.Call
 
 interface PlacesApi {
     @GET("nearbysearch/json?radius=5000&type=restaurant")

--- a/app/src/main/java/com/finder/storage/SuggestionDao.kt
+++ b/app/src/main/java/com/finder/storage/SuggestionDao.kt
@@ -1,7 +1,10 @@
 package com.finder.storage
 
 import androidx.lifecycle.LiveData
-import androidx.room.*
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
 import com.finder.Suggestion
 
 @Dao

--- a/app/src/main/java/com/finder/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/finder/ui/detail/DetailFragment.kt
@@ -2,7 +2,6 @@ package com.finder.ui.detail
 
 import android.content.Intent
 import android.graphics.Paint
-import android.graphics.Typeface
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -13,19 +12,10 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.bumptech.glide.Glide
 import com.finder.R
-import com.finder.databinding.DetailFragmentBinding
 import com.finder.Suggestion
+import com.finder.databinding.DetailFragmentBinding
 import com.finder.networking.DetailsResponse
 import io.reactivex.disposables.CompositeDisposable
-import android.text.Spannable
-
-import android.text.style.AbsoluteSizeSpan
-
-import android.text.style.StyleSpan
-
-import android.text.SpannableString
-import android.text.SpannableStringBuilder
-import androidx.core.text.bold
 
 
 private const val KEY_SUGGESTION_ID = "key.suggestion_id"

--- a/app/src/main/java/com/finder/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/finder/ui/detail/DetailViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.finder.MyApp
-import com.finder.networking.PlacesManager
 import com.finder.Suggestion
 import com.finder.networking.DetailsResponse
+import com.finder.networking.PlacesManager
 import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/finder/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/finder/ui/main/MainFragment.kt
@@ -1,21 +1,21 @@
 package com.finder.ui.main
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isVisible
-import androidx.fragment.app.viewModels
-import androidx.recyclerview.widget.LinearLayoutManager
-import com.finder.databinding.MainFragmentBinding
-import com.finder.ui.detail.DetailFragment
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.finder.R
+import com.finder.databinding.MainFragmentBinding
 import com.finder.networking.SearchResponse
 import com.finder.toSuggestionLite
+import com.finder.ui.detail.DetailFragment
 import com.finder.ui.map.MapFragment
 
 private const val LAT_PARAM = "lat_bundle_param"
@@ -189,7 +189,8 @@ class MainFragment : Fragment() {
           // `binding.root.id` wasn't working for me, but this did
           replace(
             ((view as ViewGroup).parent as View).id,
-            DetailFragment.newInstance(action.suggestion)
+            DetailFragment.newInstance(action.suggestion),
+            DetailFragment.TAG
           )
           setReorderingAllowed(true)
           addToBackStack(TAG)
@@ -199,7 +200,8 @@ class MainFragment : Fragment() {
         parentFragmentManager.commit {
           replace(
             ((view as ViewGroup).parent as View).id,
-            MapFragment.newInstance(action.suggestionList)
+            MapFragment.newInstance(action.suggestionList),
+            MapFragment.TAG
           )
           setReorderingAllowed(true)
           addToBackStack(TAG)
@@ -211,11 +213,4 @@ class MainFragment : Fragment() {
     }
   }
 
-}
-
-infix fun ViewGroup.displayedChild(view: View?) {
-  for (index in 0 until childCount) {
-    val child = getChildAt(index)
-    child.isVisible = child === view
-  }
 }

--- a/app/src/main/java/com/finder/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/finder/ui/main/MainViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.finder.MyApp
-import com.finder.networking.PlacesManager
 import com.finder.Suggestion
 import com.finder.SuggestionLite
+import com.finder.networking.PlacesManager
 import com.finder.networking.SearchResponse
 import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject

--- a/app/src/main/java/com/finder/ui/main/SuggestionAdapter.kt
+++ b/app/src/main/java/com/finder/ui/main/SuggestionAdapter.kt
@@ -7,8 +7,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.finder.BuildConfig
 import com.finder.R
-import com.finder.databinding.SuggestionItemBinding
 import com.finder.Suggestion
+import com.finder.databinding.SuggestionItemBinding
 
 typealias SuggestionActionHandler = (SuggestionAction) -> Unit
 

--- a/app/src/main/res/layout/detail_fragment.xml
+++ b/app/src/main/res/layout/detail_fragment.xml
@@ -60,18 +60,22 @@
             android:id="@+id/image"
             android:layout_width="250dp"
             android:layout_height="250dp"
+            android:contentDescription="@string/image_cont_desc"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
 
         <TextView
             android:id="@+id/name"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:textSize="@dimen/hugeTextSize"
+            android:maxLines="2"
+            android:ellipsize="end"
             app:layout_constraintTop_toBottomOf="@id/image"
             app:layout_constraintStart_toStartOf="parent"
-            tools:text="Jordan's Jams"/>
+            app:layout_constraintEnd_toStartOf="@id/favorite_icon"
+            tools:text="Jordan's Jam but the really long version of the title"/>
 
         <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/favorite_icon"
@@ -82,6 +86,7 @@
             android:enabled="true"
             android:visibility="gone"
             app:layout_constraintStart_toEndOf="@id/name"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/name"
             app:layout_constraintBottom_toBottomOf="@id/name"
             tools:src="@drawable/favorite_disabled"/>
@@ -139,8 +144,6 @@
             android:textColor="@color/dark_grey"
             android:textSize="@dimen/largeTextSize"
             tools:text="Some review stuff" />
-
-
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
 
     <!--  Used for Detail Fragment  -->
     <string name="review_prefix">Most recent reviews:\n\n%s</string>
+    <string name="image_cont_desc">Suggestion image</string>
 </resources>


### PR DESCRIPTION
After creating the release and regression testing I noticed an issue with the `DetailFragment` having a title that was quite long. I updated the `ContraintLayout` attrs to automagically create the `name` width so everything will fit properly 

Also I removed a bunch of old, unused imports. It appears the Clean Up pre-release didn't catch them all 

Finally, increment the version #! 